### PR TITLE
Add map points validation before rendering maps

### DIFF
--- a/src/components/ActivityBox.tsx
+++ b/src/components/ActivityBox.tsx
@@ -211,7 +211,7 @@ const ActivityBox = ({ activity, isDetailed = false }: ActivityBoxProps) => {
         </Grid>
       </Grid>
       <Grid size={{ xs: 12, md: 6 }} sx={{ minHeight: isMobile ? "250px" : "auto" }}>
-        {mapProvider === "leaflet" && activity.sport !== "swimming" ? (
+        {mapPoints.length >= 2 && activity.sport !== "swimming" && mapProvider === "leaflet" ? (
           <MapComponent
             bounds={[
               [activity.lat - activity.delta_lat, activity.lon - activity.delta_lon],
@@ -219,7 +219,7 @@ const ActivityBox = ({ activity, isDetailed = false }: ActivityBoxProps) => {
             ]}
             points={mapPoints}
           />
-        ) : mapProvider === "openlayers" && activity.sport !== "swimming" ? (
+        ) : mapPoints.length >= 2 && activity.sport !== "swimming" && mapProvider === "openlayers" ? (
           <MapOLComponent
             bounds={[
               [activity.lat - activity.delta_lat, activity.lon - activity.delta_lon],
@@ -227,7 +227,7 @@ const ActivityBox = ({ activity, isDetailed = false }: ActivityBoxProps) => {
             ]}
             points={mapPoints}
           />
-        ) : activity.sport !== "swimming" ? (
+        ) : mapPoints.length >= 2 && activity.sport !== "swimming" ? (
           <MapMapbox
             bounds={[
               [activity.lat - activity.delta_lat, activity.lon - activity.delta_lon],

--- a/tests/components/ActivityBox.test.tsx
+++ b/tests/components/ActivityBox.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import ActivityBox from "../../src/components/ActivityBox";
+import type { Activity } from "../../src/types";
+
+vi.mock("../../src/store", () => ({
+  useAuthStore: vi.fn(() => ({ user: { map: "leaflet" } })),
+}));
+
+vi.mock("../../src/components/Map", () => ({
+  default: ({ points }: { points: unknown[] }) => <div data-testid="map-leaflet">{points.length} points</div>,
+}));
+
+vi.mock("../../src/components/MapOL", () => ({
+  default: ({ points }: { points: unknown[] }) => <div data-testid="map-ol">{points.length} points</div>,
+}));
+
+vi.mock("../../src/components/MapMapbox", () => ({
+  default: ({ points }: { points: unknown[] }) => <div data-testid="map-mapbox">{points.length} points</div>,
+}));
+
+vi.mock("../../src/components/EditActivityModal", () => ({
+  default: () => <div data-testid="edit-modal" />,
+}));
+
+vi.mock("../../src/components/ActivityLogo", () => ({
+  default: () => <div data-testid="activity-logo" />,
+}));
+
+const theme = createTheme();
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+    </MemoryRouter>,
+  );
+
+const createMockActivity = (overrides: Partial<Activity> = {}): Activity =>
+  ({
+    id: "123e4567-e89b-12d3-a456-426614174000",
+    fit: "test.fit",
+    title: "Morning Run",
+    description: "",
+    sport: "running",
+    device: "Garmin",
+    race: false,
+    start_time: 1700000000,
+    timestamp: 1700000000,
+    total_timer_time: 3600,
+    total_elapsed_time: 3700,
+    total_distance: 10000,
+    total_ascent: 100,
+    avg_speed: 10,
+    avg_heart_rate: 150,
+    max_heart_rate: 180,
+    avg_cadence: 170,
+    max_cadence: 190,
+    avg_power: null,
+    max_power: null,
+    np_power: null,
+    total_calories: null,
+    total_training_effect: null,
+    training_stress_score: null,
+    intensity_factor: null,
+    avg_temperature: null,
+    max_temperature: null,
+    min_temperature: null,
+    pool_length: null,
+    num_lengths: null,
+    lat: 48.8566,
+    lon: 2.3522,
+    delta_lat: 0.01,
+    delta_lon: 0.01,
+    city: "Paris",
+    subdivision: null,
+    country: "France",
+    user_id: "user-1",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    laps: [],
+    performances: [],
+    performance_power: [],
+    notifications: [],
+    tracepoints: [],
+    status: "created",
+    ...overrides,
+  }) as Activity;
+
+describe("ActivityBox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders activity title", () => {
+    const activity = createMockActivity({ title: "Treadmill 5k" });
+    renderWithProviders(<ActivityBox activity={activity} />);
+    expect(screen.getByText("Treadmill 5k")).toBeInTheDocument();
+  });
+
+  it("does not render map when tracepoints are empty", () => {
+    const activity = createMockActivity({ tracepoints: [] });
+    renderWithProviders(<ActivityBox activity={activity} />);
+    expect(screen.queryByTestId("map-leaflet")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("map-ol")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("map-mapbox")).not.toBeInTheDocument();
+  });
+
+  it("does not render map when tracepoints are absent", () => {
+    const activity = createMockActivity({ tracepoints: undefined });
+    renderWithProviders(<ActivityBox activity={activity} />);
+    expect(screen.queryByTestId("map-leaflet")).not.toBeInTheDocument();
+  });
+
+  it("renders map when tracepoints has 2 or more points", () => {
+    const activity = createMockActivity({
+      tracepoints: [
+        { lat: 48.85, lon: 2.35, timestamp: "2024-01-01T00:00:00Z", distance: 0, heart_rate: 150, speed: 10, cadence: null, power: null, altitude: 100, temperature: null },
+        { lat: 48.86, lon: 2.36, timestamp: "2024-01-01T00:01:00Z", distance: 100, heart_rate: 155, speed: 11, cadence: null, power: null, altitude: 101, temperature: null },
+      ],
+    });
+    renderWithProviders(<ActivityBox activity={activity} />);
+    expect(screen.getByTestId("map-leaflet")).toBeInTheDocument();
+  });
+});

--- a/tests/components/ActivityBox.test.tsx
+++ b/tests/components/ActivityBox.test.tsx
@@ -112,8 +112,23 @@ describe("ActivityBox", () => {
     expect(screen.queryByTestId("map-mapbox")).not.toBeInTheDocument();
   });
 
-  it("does not render map when tracepoints are absent", () => {
-    const activity = createMockActivity({ tracepoints: undefined });
+  it("does not render map when tracepoints has only 1 point", () => {
+    const activity = createMockActivity({
+      tracepoints: [
+        {
+          lat: 48.85,
+          lon: 2.35,
+          timestamp: "2024-01-01T00:00:00Z",
+          distance: 0,
+          heart_rate: 150,
+          speed: 10,
+          cadence: null,
+          power: null,
+          altitude: 100,
+          temperature: null,
+        },
+      ],
+    });
     renderWithProviders(<ActivityBox activity={activity} />);
     expect(screen.queryByTestId("map-leaflet")).not.toBeInTheDocument();
   });

--- a/tests/components/ActivityBox.test.tsx
+++ b/tests/components/ActivityBox.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ActivityBox from "../../src/components/ActivityBox";
 import type { Activity } from "../../src/types";
 
@@ -121,8 +121,30 @@ describe("ActivityBox", () => {
   it("renders map when tracepoints has 2 or more points", () => {
     const activity = createMockActivity({
       tracepoints: [
-        { lat: 48.85, lon: 2.35, timestamp: "2024-01-01T00:00:00Z", distance: 0, heart_rate: 150, speed: 10, cadence: null, power: null, altitude: 100, temperature: null },
-        { lat: 48.86, lon: 2.36, timestamp: "2024-01-01T00:01:00Z", distance: 100, heart_rate: 155, speed: 11, cadence: null, power: null, altitude: 101, temperature: null },
+        {
+          lat: 48.85,
+          lon: 2.35,
+          timestamp: "2024-01-01T00:00:00Z",
+          distance: 0,
+          heart_rate: 150,
+          speed: 10,
+          cadence: null,
+          power: null,
+          altitude: 100,
+          temperature: null,
+        },
+        {
+          lat: 48.86,
+          lon: 2.36,
+          timestamp: "2024-01-01T00:01:00Z",
+          distance: 100,
+          heart_rate: 155,
+          speed: 11,
+          cadence: null,
+          power: null,
+          altitude: 101,
+          temperature: null,
+        },
       ],
     });
     renderWithProviders(<ActivityBox activity={activity} />);


### PR DESCRIPTION
## Summary
Added validation to ensure maps only render when there are sufficient data points (at least 2 points), preventing potential rendering errors or empty map displays.

## Key Changes
- Added `mapPoints.length >= 2` check to all three map provider conditionals (Leaflet, OpenLayers, and Mapbox)
- Reordered condition checks to validate map points availability before checking the map provider type
- This ensures maps are only rendered when there is meaningful geographic data to display

## Implementation Details
The validation is applied consistently across all three map rendering branches:
- Leaflet map component
- OpenLayers map component  
- Mapbox map component

The check prevents attempting to render maps with insufficient data points, which could cause rendering issues or display empty/invalid map views. Swimming activities continue to be excluded from map rendering as before.

https://claude.ai/code/session_01EK8is2a19CdhCZdJsnQHT8