### PR TITLE
fix(docker): install build-base so psycopg2 compiles in builder stage

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.13-alpine AS builder
 
 WORKDIR /code
 
-RUN apk add --no-cache postgresql-dev
+RUN apk add --no-cache build-base postgresql-dev
 
 RUN pip install --no-cache-dir uv
 


### PR DESCRIPTION
The Alpine builder stage installed postgresql-dev (headers) but no C
compiler, so building psycopg2 from source failed with
'command gcc failed: No such file or directory', breaking the docker
job on main. Add build-base to provide gcc/make/musl-dev.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A6rxr9aCwfoeLFVuKvJBYk