### PR TITLE
Upgrade Playwright to v1.61.0

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-jammy
+      image: mcr.microsoft.com/playwright:v1.61.0-jammy
     steps:
     - uses: actions/checkout@v4
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
         "@chromatic-com/storybook": "^5.2.1",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.61.0",
         "@storybook/addon-docs": "^10.4.5",
         "@storybook/addon-vitest": "^10.4.4",
         "@storybook/react": "^10.4.3",
@@ -60,7 +60,7 @@
         "chromatic": "^17.4.1",
         "jsdom": "^29.1.1",
         "nyc": "^18.0.0",
-        "playwright": "^1.60.0",
+        "playwright": "^1.61.0",
         "storybook": "^10.3.4",
         "typescript": "^6.0.3",
         "vite": "^8.0.16",
@@ -2529,13 +2529,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7028,13 +7028,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7047,9 +7047,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@chromatic-com/storybook": "^5.2.1",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.0",
     "@storybook/addon-docs": "^10.4.5",
     "@storybook/addon-vitest": "^10.4.4",
     "@storybook/react": "^10.4.3",
@@ -71,7 +71,7 @@
     "chromatic": "^17.4.1",
     "jsdom": "^29.1.1",
     "nyc": "^18.0.0",
-    "playwright": "^1.60.0",
+    "playwright": "^1.61.0",
     "storybook": "^10.3.4",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",


### PR DESCRIPTION
## Summary
Updates Playwright testing dependencies to the latest version (v1.61.0) for both the test runner and browser binaries.

## Changes
- Bumped `@playwright/test` from v1.60.0 to v1.61.0
- Bumped `playwright` from v1.60.0 to v1.61.0

This ensures consistency between the test framework and browser binaries, and brings in the latest bug fixes and improvements from the Playwright project.

https://claude.ai/code/session_01EcvvZuLRncLkGeAG6KSKve