### PR TITLE
Pin ruff version to 0.15.21 in CI workflow

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           src: api
+          version: 0.15.21
       - run: ruff format
       - run: ruff check
 


### PR DESCRIPTION
## Summary
Pins the ruff linter version to 0.15.21 in the GitHub Actions workflow to ensure consistent code quality checks across CI runs.

## Key Changes
- Added explicit `version: 0.15.21` parameter to the `astral-sh/ruff-action@v3` step in the Python CI workflow

## Details
This change ensures that the ruff linter used in CI maintains a consistent version, preventing unexpected behavior changes from automatic version updates. This aligns with the project's code quality standards where ruff is the primary linting and formatting tool for Python code.

https://claude.ai/code/session_01DKiNWpc7NVG1X6fku2XbxY