### PR TITLE
Bump playwright to 1.62.1

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.61.0-jammy
+      image: mcr.microsoft.com/playwright:v1.62.1-jammy
     steps:
     - uses: actions/checkout@v4
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.5",
         "@chromatic-com/storybook": "^5.2.1",
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.1",
         "@storybook/addon-docs": "^10.5.5",
         "@storybook/addon-vitest": "^10.5.3",
         "@storybook/react": "^10.5.5",
@@ -60,7 +60,7 @@
         "chromatic": "^18.1.0",
         "jsdom": "^29.1.1",
         "nyc": "^18.0.0",
-        "playwright": "^1.61.1",
+        "playwright": "^1.62.1",
         "storybook": "^10.3.4",
         "typescript": "^7.0.2",
         "vite": "^8.1.5",
@@ -467,9 +467,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -487,9 +484,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -507,9 +501,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -527,9 +518,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2517,19 +2505,19 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -7273,35 +7261,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",
     "@chromatic-com/storybook": "^5.2.1",
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.1",
     "@storybook/addon-docs": "^10.5.5",
     "@storybook/addon-vitest": "^10.5.3",
     "@storybook/react": "^10.5.5",
@@ -71,7 +71,7 @@
     "chromatic": "^18.1.0",
     "jsdom": "^29.1.1",
     "nyc": "^18.0.0",
-    "playwright": "^1.61.1",
+    "playwright": "^1.62.1",
     "storybook": "^10.3.4",
     "typescript": "^7.0.2",
     "vite": "^8.1.5",


### PR DESCRIPTION
## Summary

Bumps Playwright to version 1.62.1.

## Changes

- **package.json** — `@playwright/test` and `playwright` bumped from `^1.61.1` → `^1.62.1`
- **package-lock.json** — regenerated; `@playwright/test`, `playwright`, and `playwright-core` now resolve to 1.62.1
- **.github/workflows/js.yaml** — CI container image `mcr.microsoft.com/playwright:v1.61.0-jammy` → `v1.62.1-jammy` to match the bumped version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012rWB62rus4tXA5YTDHNjj6)_